### PR TITLE
build(npm): change `author` to `Catppuccin Org`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "type": "module",
   "version": "0.1.0",
   "description": "📝 Soothing pastel theme for VitePress",
-  "author": "willow <42willow@pm.me>",
+  "author": "Catppuccin Org <releases@catppuccin.com>",
+  "contributors": [
+    "willow <42willow@pm.me>"
+  ],
   "license": "MIT",
   "files": [
     "theme/"


### PR DESCRIPTION
Matches our guidelines and the existing [highlightjs](https://github.com/catppuccin/highlightjs/blob/d06ee177c4ceec8840d2db0a4396e7cc77af765b/package.json#L6-L10) port.
